### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/CSV/libcsv.c
+++ b/CSV/libcsv.c
@@ -158,15 +158,14 @@ csv_free(struct csv_parser *p)
 int
 csv_fini(struct csv_parser *p, void (*cb1)(void *, size_t, void *), void (*cb2)(int c, void *), void *data)
 {
-  /* Finalize parsing.  Needed, for example, when file does not end in a newline */
+	if (p == NULL)
+		return -1;
+
+	/* Finalize parsing.  Needed, for example, when file does not end in a newline */
   int quoted = p->quoted;
   int pstate = p->pstate;
   size_t spaces = p->spaces;
   size_t entry_pos = p->entry_pos;
-
-  if (p == NULL)
-    return -1;
-
 
   if (p->pstate == FIELD_BEGUN && p->quoted && p->options & CSV_STRICT && p->options & CSV_STRICT_FINI) {
     /* Current field is quoted, no end-quote was seen, and CSV_STRICT_FINI is set */

--- a/stresstest/read.cpp
+++ b/stresstest/read.cpp
@@ -195,7 +195,7 @@ bool read_records(
         DEBUG_IF( ( b ),
             "Random access: More records than expected." );
 
-        DEBUG_IF( ( !csv_read.eof || ( expected_records_count != csv_read.end_record_num ) ),
+        DEBUG_IF( !csv_read.eof || ( expected_records_count != csv_read.end_record_num ),
             "Random access: End record unknown." );
 
         records.assign( tmprec.begin(), tmprec.end() );


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V592](https://www.viva64.com/en/w/v592/) The expression was enclosed by parentheses twice: ((expression)). One pair of parentheses is unnecessary or misprint is present. read.cpp 198
[V595](https://www.viva64.com/en/w/v595/) The 'p' pointer was utilized before it was verified against nullptr. Check lines: 162, 167. libcsv.c 162